### PR TITLE
Add getElement and getElements

### DIFF
--- a/src/Enzyme.re
+++ b/src/Enzyme.re
@@ -31,6 +31,8 @@ module Renderer = {
   [@bs.send] external text : t => string = "text";
   [@bs.send] external html : t => string = "html";
   [@bs.send.pipe : t] external get : int => node = "get";
+  [@bs.send] external getElement : t => node = "getElement";
+  [@bs.send] external getElements : t => array(node) = "getElements";
   [@bs.send] external getNode : t => node = "getNode";
   [@bs.send] external getNodes : t => array(node) = "getNodes";
   [@bs.send.pipe : t] external at : int => t = "at";


### PR DESCRIPTION
Hello there, 

Thanks for this binding library ! I've been using it to create behaviour tests in my ReasonML application. 

I have been trying to snapshot test after simulating user's actions using enzyme. The snapshot method actually takes a `ReasonReact.reactElement`. When I tried to use `getNode` a warning said that the method was deprecated and that we should rather use `getElement`. Enzyme changelog is here https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md#documentation-2

I've added the two missing methods in the bindings (I intentionally left the deprecated `getNode` and `getNodes` methods for people to get the warning message)